### PR TITLE
reduce attr bitset memory

### DIFF
--- a/src/attr/multi_bitset_manager.h
+++ b/src/attr/multi_bitset_manager.h
@@ -116,6 +116,9 @@ private:
     /// A vector containing pointers to ComputableBitset instances.
     Vector<ComputableBitset*> bitsets_;
 
+    /// map origin id to inner id (avoiding nullptr)
+    Vector<int16_t> bitset_map_;
+
     /// The current number of ComputableBitset instances managed by this object. Defaults to 1.
     uint64_t count_{1};
 


### PR DESCRIPTION
## Summary by Sourcery

Compact bitset storage by mapping original IDs to a contiguous bitsets_ array, reducing memory usage and updating associated methods and serialization accordingly.

Enhancements:
- Introduce bitset_map_ to compact bitset storage and eliminate null placeholders
- Update GetOneBitset, SetNewCount, InsertValue, and serialization/deserialization to use the new mapping